### PR TITLE
[FEAT] : 데뷔조 삭제 기능 구현 완료.

### DIFF
--- a/src/main/java/produce365/debut/DebutServlet.java
+++ b/src/main/java/produce365/debut/DebutServlet.java
@@ -11,8 +11,13 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jdt.internal.compiler.batch.Main;
+
 @WebServlet("/debuts/*")
 public class DebutServlet extends HttpServlet {
+	
+	
+	
 	@Override
 	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 		process(req, resp);
@@ -55,15 +60,18 @@ public class DebutServlet extends HttpServlet {
 					Integer.parseInt(req.getParameter("id")));
 			debutDAO.update(debut);
 			
-		} else if (action.equals("delete")) {
+		} else if (action.equals("delete")) { //경로가 delete일때,
 			
-			int deleteId = Integer.parseInt(req.getParameter("id"));
+			//int id = Integer.parseInt(req.getParameter("id"));
+			//int형 변수 id에 Integer로 감싼 "id"라는 name을 가진 변수를 리퀘스트하고
 			
-			JDBCDebutDAO debut = new JDBCDebutDAO();
+			JDBCDebutDAO debutDAO = new JDBCDebutDAO(); 
+			//debutDAO라고 하는 새로운 JDBCDebutDAO형 객체를 만들어
 			
-			req.setAttribute("delete", debut.deleteById(deleteId));
-			
+			debutDAO.deleteById(Integer.parseInt(req.getParameter("id")));
+			//debutDAO에 대하여 deleteById라는 메소드를 실행하는데, 그 매개변수로 위의 id를 넣는다.
 
+			
 		} else if (action.equals("save")) {
 			// 새 데뷔조 만들기 : 저장하기 버튼 눌렀을 때
 			DebutDAO debutDAO = new JDBCDebutDAO();
@@ -99,5 +107,6 @@ public class DebutServlet extends HttpServlet {
 		RequestDispatcher rd = req.getRequestDispatcher(dispatcherUrl);
 		rd.forward(req, resp);
 
+	
 	}
 }

--- a/src/main/webapp/debut/debutNew.jsp
+++ b/src/main/webapp/debut/debutNew.jsp
@@ -105,7 +105,7 @@
 					<button type="button" id="save" onclick="checkInput()">저장하기</button>
 				</div>
 				<div class="col">
-					<button type="button" id="toList" onclick="checkToList()">목록으로</button>
+					<button type="button" id="toList" onclick="location.href='debuts'">목록으로</button>
 				</div>
 			</div>
 		</div>

--- a/src/main/webapp/debut/debutUpdate.jsp
+++ b/src/main/webapp/debut/debutUpdate.jsp
@@ -117,7 +117,7 @@
 				</div>
 				
 				<div class="col">
-					<button type="button" id="toList" onclick="">목록으로</button>
+					<button type="button" id="toList" onclick="location.href='debuts'">목록으로</button>
 				</div>
 			
 			</div>

--- a/src/main/webapp/debut/debutUpdate.jsp
+++ b/src/main/webapp/debut/debutUpdate.jsp
@@ -111,7 +111,9 @@
 				</div>
 				
 				<div class="col">
-					<button type="button" name="delete" id="delete" onclick="checkDelete()">삭제하기</button>
+					<button type="button" id="deletebutton" onclick="location.href='debuts/delete?id=${debut.id}'">삭제하기</button>
+					<!-- type이 button인 버튼은 delete라는 id를 가지고 있고, 클릭하면 checkDelete 메소드를 실행 -->
+					
 				</div>
 				
 				<div class="col">
@@ -141,7 +143,7 @@
 			const concept = document.getElementById("concept").value;
 			const debutDate = document.getElementById("debutDate").value;
 			const grade = document.getElementById("grade").value;
-			const form = document.getElementById("form")
+			const form = document.getElementById("form");
 
 			if (name != "" && memeberCount != "" && concept != ""
 					&& debutDate != "" && grade != "") {
@@ -151,17 +153,24 @@
 			}
 		}
 		
-		function checkDelete() {
-			const id = document.getElementById("id").value;
-			const form = document.getElementById("form")
+		
+	/* 	function checkDelete() {
 			
-			if(id !=""){
+			const id = document.getElementById("id").value;
+			/* id 변수에 id라는 아이디를 가진 문서의 내용 값을 넣는다. */
+			
+			const form = document.getElementById("form");
+			/*form 변수에 form라는 아이디를 가진 문서의 내용 값을 넣는다. */
+			
+			if(id == ""){ /* id가 비어있지 않으면,  */
+				alert("다시 입력하세요!"); 
+				/* form에 대하여 submit 메소드를 실행하라. */
+			}else { /* 그렇지 않으면,(id가 null 이면) */
 				form.submit();
-			}else {
-				alert("다시 입력하세요!");
+				/* alert(다시 입력하세요) 라는 경고창으 띄워라. */
 			}
 		}
-		
+		 */
 	
 		const DMSModalOpen = document.querySelector("#DMSModal-open");
 		const modalBox = document.querySelector("#modal-box");


### PR DESCRIPTION
<작업내용>
1. 데뷔조 업데이트 페이지에서 delete 버튼 클릭하면, 바로 삭제되어 리스트로 이동하도록 구현.
2. [데뷔조 생성 및 업데이트 페이지에서 데뷔조 목록으로 이동하는 기능 구현

<주의사항>
1. 삭제 시 검증 절차 없이 바로 DB에서 사라짐. 